### PR TITLE
[BKY-7397] Add configurable package name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
             pkgs.git
             pkgs.go
             pkgs.gotools
+            pkgs.gopls
             pkgs.nixfmt-rfc-style
           ];
         };

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -159,6 +160,9 @@ func makeIntAndBytesExamples() ([]IntAndBytesExample, error) {
 }
 
 func main() {
+	packageName := flag.String("package-name", "abitestdata", "package name")
+	flag.Parse()
+
 	sliceOfBytes, err := makeSliceOfByteSliceExamples()
 	exitOnError("creating slice of bytes examples", err)
 
@@ -169,7 +173,7 @@ func main() {
 	exitOnError("creating int and bytes examples", err)
 
 	renderer := Renderer{
-		packageName:  "abitestdata",
+		packageName:  *packageName,
 		sliceOfBytes: sliceOfBytes,
 		allInts:      allInts,
 		intAndBytes:  intAndBytes,


### PR DESCRIPTION
Previously, the package name for the output was always abitestdata.  This PR adds the `--package-name` command, so that a user can configure the name of the package of the output file.